### PR TITLE
trying error mismatch handling

### DIFF
--- a/common/error.go
+++ b/common/error.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -58,6 +59,13 @@ func StringError(err error, optionalMsg ...string) error {
 
 	for _, msgs := range optionalMsg {
 		concat += msgs + " "
+	}
+
+	// Fix type mismatch from external libraries
+	t := reflect.TypeOf(err)
+	_, ok := t.MethodByName("Wrap")
+	if !ok {
+		err = errors.New(err.Error())
 	}
 
 	if errors.Cause(err) == nil || errors.Cause(err) == err {


### PR DESCRIPTION
Stringify errors which do not contain the Wrap method to prevent PANIC in error.go.

To test:

1) Send all of your test AVAX to me
2) go get this PR in your string-api using `go get github.com/String-xyz/go-lib@63079fdd341a3701a902d994a2969e937916ef87`
3) Docker compose down
4) Docker compose up
6) Create an account using the Platform Admin API
7) Log in using Postman and create an API key
8) Create a user on String API using Postman
9) Request a quote
10) The w3 package will return it's own error type which does not contain a wrap method, this will get passed into our error handler and stringified accordingly.  You should see the normal error printout and NO PANIC!

`STACK TRACE:
: : w3: call failed: err: insufficient funds for gas * price + value: address 0x44A4b9E2A69d86BA382a511f845CbF2E31286770 have 105000000000000 want 80000000000000000 (supplied gas 4010499): [
github.com/String-xyz/go-lib/common.StringError
        /go/pkg/mod/github.com/!string-xyz/go-lib@v1.3.1-0.20230328194951-63079fdd341a/common/error.go:72
github.com/String-xyz/string-api/pkg/service.transaction.Quote
        pkg/service/transaction.go:98
github.com/String-xyz/string-api/api/handler.quote.Quote
        api/handler/quotes.go:43
github.com/labstack/echo/v4/middleware.JWTWithConfig.func1.1
        /go/pkg/mod/github.com/labstack/echo/v4@v4.10.0/middleware/jwt.go:236
github.com/labstack/echo/v4/middleware.KeyAuthWithConfig.func1.1
        /go/pkg/mod/github.com/labstack/echo/v4@v4.10.0/middleware/key_auth.go:137 ]`