### PR TITLE
Task/sean/str 547

### DIFF
--- a/common/error.go
+++ b/common/error.go
@@ -60,7 +60,7 @@ func StringError(err error, optionalMsg ...string) error {
 		concat += msgs + " "
 	}
 
-	if errors.Cause(err) == nil || errors.Cause(err) == err {
+	if errors.Cause(err) == nil || errors.Cause(err).Error() == err.Error() {
 		fmt.Printf("\nWrapping Nil or Top Level Error %+v\n", err)
 		return errors.Wrap(errors.New(err.Error()), concat)
 	}

--- a/common/error.go
+++ b/common/error.go
@@ -40,7 +40,7 @@ func LogStringError(c echo.Context, err error, handlerMsg string) {
 	}
 
 	if IsLocalEnv() {
-		st2 := fmt.Sprintf("\nSTACK TRACE:\n%+v: [%+v ]\n\n", cause.Error(), st[0:5])
+		st2 := fmt.Sprintf("\nSTACK TRACE:\n%+v: [%+v ]\n\n", cause.Error(), st)
 		// delete the string_api docker path from the stack trace
 		st2 = strings.ReplaceAll(st2, "/"+serviceName+"/", "")
 		fmt.Print(st2)
@@ -55,6 +55,8 @@ func StringError(err error, optionalMsg ...string) error {
 		return nil
 	}
 
+	fmt.Printf("\nGot Error %+v\n", err)
+
 	concat := ""
 
 	for _, msgs := range optionalMsg {
@@ -65,10 +67,12 @@ func StringError(err error, optionalMsg ...string) error {
 	t := reflect.TypeOf(err)
 	_, ok := t.MethodByName("Wrap")
 	if !ok {
+		fmt.Printf("\nWrapping Mismatch Error %+v\n", err)
 		err = errors.New(err.Error())
 	}
 
 	if errors.Cause(err) == nil || errors.Cause(err) == err {
+		fmt.Printf("\nWrapping Nil or Top Level Error %+v\n", err)
 		return errors.Wrap(errors.New(err.Error()), concat)
 	}
 

--- a/common/error.go
+++ b/common/error.go
@@ -3,7 +3,6 @@ package common
 import (
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -55,21 +54,13 @@ func StringError(err error, optionalMsg ...string) error {
 		return nil
 	}
 
-	fmt.Printf("\nGot Error %+v\n", err)
-
 	concat := ""
 
 	for _, msgs := range optionalMsg {
 		concat += msgs + " "
 	}
 
-	// Fix type mismatch from external libraries
-	t := reflect.TypeOf(err)
-	_, ok := t.MethodByName("Wrap")
-	if !ok {
-		fmt.Printf("\nWrapping Mismatch Error %+v\n", err)
-		err = errors.Wrap(errors.New(err.Error()), concat)
-	} else if errors.Cause(err) == nil || errors.Cause(err) == err {
+	if errors.Cause(err) == nil || errors.Cause(err) == err {
 		fmt.Printf("\nWrapping Nil or Top Level Error %+v\n", err)
 		return errors.Wrap(errors.New(err.Error()), concat)
 	}

--- a/common/error.go
+++ b/common/error.go
@@ -61,7 +61,6 @@ func StringError(err error, optionalMsg ...string) error {
 	}
 
 	if errors.Cause(err) == nil || errors.Cause(err).Error() == err.Error() {
-		fmt.Printf("\nWrapping Nil or Top Level Error %+v\n", err)
 		return errors.Wrap(errors.New(err.Error()), concat)
 	}
 

--- a/common/error.go
+++ b/common/error.go
@@ -68,10 +68,8 @@ func StringError(err error, optionalMsg ...string) error {
 	_, ok := t.MethodByName("Wrap")
 	if !ok {
 		fmt.Printf("\nWrapping Mismatch Error %+v\n", err)
-		err = errors.New(err.Error())
-	}
-
-	if errors.Cause(err) == nil || errors.Cause(err) == err {
+		err = errors.Wrap(errors.New(err.Error()), concat)
+	} else if errors.Cause(err) == nil || errors.Cause(err) == err {
 		fmt.Printf("\nWrapping Nil or Top Level Error %+v\n", err)
 		return errors.Wrap(errors.New(err.Error()), concat)
 	}


### PR DESCRIPTION
This PR resolves a bug where the upper layers of the Error stack get clobbered.

To test:
1) Docker Compose Down
2) Docker Compose Up
3) Create a platform using the Platform Admin App, verify your email
4) Switch over to Postman and log in to the Platform Admin App
5) Create an API key
6) List Networks
7) Contracts > Create Avalanche
8) Request a Login payload in the String API
9) Log in / create a user in the String API
10) Go to get a quote using Transaction > Avalanche Quote BUT CHANGE the txValue to 0.07 eth
11) This generates an external error in the w3 package which does not implement Cause() !!!
12) The console output should show the full stack trace with pkg/service/executor.go:92 as the second entry, right under error.go:65