### PR TITLE
Task/sean/str 556

### DIFF
--- a/common/id_prefix.go
+++ b/common/id_prefix.go
@@ -1,0 +1,97 @@
+package common
+
+import (
+	"reflect"
+
+	"github.com/pkg/errors"
+)
+
+var modelIdPrefixes = map[string]string{
+	"User":         "user",
+	"Platform":     "platform",
+	"Network":      "network",
+	"Asset":        "asset",
+	"Device":       "device",
+	"Contact":      "contact",
+	"Location":     "location",
+	"Instrument":   "instrument",
+	"TxLeg":        "txleg",
+	"Transaction":  "tx",
+	"AuthStrategy": "auth",
+	"ApiKey":       "apikey",
+	"Contract":     "contract",
+}
+
+var relationalIdPrefixes = map[string]string{
+	"UserId":             "user",
+	"PlatformId":         "platform",
+	"ContactId":          "contact",
+	"DeviceId":           "device",
+	"InstrumentId":       "instrument",
+	"NetworkId":          "network",
+	"OriginTxLegId":      "txleg",
+	"DestinationTxLegId": "txleg",
+	"ReceiptTxId":        "txleg",
+	"ResponseTxId":       "txleg",
+	"AssetId":            "asset",
+}
+
+func SanitizeIdInput(model interface{}) error {
+	// Model ID
+	stype := reflect.ValueOf(model).Elem()
+	field := stype.FieldByName("Id")
+	if !field.IsValid() {
+		// return errors.New("model does not contain an id")
+		// model may be relational, continue
+	} else {
+		prefix, ok := modelIdPrefixes[stype.Type().Name()]
+		if !ok {
+			return StringError(errors.New("model unknown"))
+		}
+		if field.String()[:len(prefix)+1] != prefix+"_" {
+			return StringError(errors.New("input missing prefix " + prefix + "_"))
+		}
+		field.SetString(field.String()[len(prefix)+1:])
+	}
+
+	// Relational IDs
+	for fieldName, prefix := range relationalIdPrefixes {
+		field := stype.FieldByName(fieldName)
+		if !field.IsValid() {
+			continue
+		}
+		if field.String()[:len(prefix)+1] != prefix+"_" {
+			return StringError(errors.New("input missing prefix " + prefix + "_"))
+		}
+		field.SetString(field.String()[len(prefix)+1:])
+	}
+
+	return nil
+}
+
+func SanitizeIdOutput(model interface{}) error {
+	// Model ID
+	stype := reflect.ValueOf(model).Elem()
+	field := stype.FieldByName("Id")
+	if !field.IsValid() {
+		// return errors.New("model does not contain an id")
+		// Model may be relational, continue
+	} else {
+		prefix, ok := modelIdPrefixes[stype.Type().Name()]
+		if !ok {
+			return StringError(errors.New("model unknown"))
+		}
+		field.SetString(prefix + "_" + field.String())
+	}
+
+	// Relational IDs
+	for fieldName, prefix := range relationalIdPrefixes {
+		field := stype.FieldByName(fieldName)
+		if !field.IsValid() {
+			continue
+		}
+		field.SetString(prefix + "_" + field.String())
+	}
+
+	return nil
+}

--- a/common/id_prefix.go
+++ b/common/id_prefix.go
@@ -36,61 +36,105 @@ var relationalIdPrefixes = map[string]string{
 	"AssetId":            "asset",
 }
 
-func SanitizeIdInput(model interface{}) error {
-	// Model ID
+func SanitizeIdInput(model interface{}, inline ...*string) error {
 	stype := reflect.ValueOf(model).Elem()
-	field := stype.FieldByName("Id")
-	if !field.IsValid() {
-		// return errors.New("model does not contain an id")
-		// model may be relational, continue
-	} else {
-		prefix, ok := modelIdPrefixes[stype.Type().Name()]
-		if !ok {
-			return StringError(errors.New("model unknown"))
+
+	// Modify struct passed in by value
+	if len(inline) == 0 {
+		// Model ID
+		field := stype.FieldByName("Id")
+		if !field.IsValid() {
+			// return errors.New("model does not contain an id")
+			// model may be relational or inline, continue
+		} else {
+			prefix, ok := modelIdPrefixes[stype.Type().Name()]
+			if !ok {
+				return StringError(errors.New("model unknown"))
+			}
+			if field.String()[:len(prefix)+1] != prefix+"_" {
+				return StringError(errors.New("input missing prefix " + prefix + "_"))
+			}
+			field.SetString(field.String()[len(prefix)+1:])
 		}
-		if field.String()[:len(prefix)+1] != prefix+"_" {
-			return StringError(errors.New("input missing prefix " + prefix + "_"))
+
+		// Relational IDs
+		// Iterating through const memory is faster than Inline logic below despite ordering of fields
+		for fieldName, prefix := range relationalIdPrefixes {
+			field := stype.FieldByName(fieldName)
+			if !field.IsValid() {
+				continue
+			}
+			if field.String()[:len(prefix)+1] != prefix+"_" {
+				return StringError(errors.New("input missing prefix " + prefix + "_"))
+			}
+			field.SetString(field.String()[len(prefix)+1:])
 		}
-		field.SetString(field.String()[len(prefix)+1:])
+		return nil
 	}
 
-	// Relational IDs
-	for fieldName, prefix := range relationalIdPrefixes {
-		field := stype.FieldByName(fieldName)
-		if !field.IsValid() {
-			continue
+	// Modify inline string pointers based on struct values
+	if len(inline) > 0 {
+		if len(inline) != stype.NumField() {
+			return StringError(errors.New("invalid inline length"))
 		}
-		if field.String()[:len(prefix)+1] != prefix+"_" {
-			return StringError(errors.New("input missing prefix " + prefix + "_"))
+		for i := 0; i < stype.NumField(); i++ {
+			field := stype.Field(i)
+			prefix, ok := relationalIdPrefixes[stype.Type().Field(i).Name]
+			if !ok {
+				return StringError(errors.New("unknown field type " + field.Type().Name()))
+			}
+			if field.String()[:len(prefix)+1] != prefix+"_" {
+				return StringError(errors.New("input missing prefix " + prefix + "_"))
+			}
+			*inline[i] = field.String()[len(prefix)+1:]
 		}
-		field.SetString(field.String()[len(prefix)+1:])
 	}
 
 	return nil
 }
 
-func SanitizeIdOutput(model interface{}) error {
-	// Model ID
+func SanitizeIdOutput(model interface{}, inline ...*string) error {
 	stype := reflect.ValueOf(model).Elem()
-	field := stype.FieldByName("Id")
-	if !field.IsValid() {
-		// return errors.New("model does not contain an id")
-		// Model may be relational, continue
-	} else {
-		prefix, ok := modelIdPrefixes[stype.Type().Name()]
-		if !ok {
-			return StringError(errors.New("model unknown"))
+
+	if len(inline) == 0 {
+		// Model ID
+		field := stype.FieldByName("Id")
+		if !field.IsValid() {
+			// return errors.New("model does not contain an id")
+			// Model may be relational, continue
+		} else {
+			prefix, ok := modelIdPrefixes[stype.Type().Name()]
+			if !ok {
+				return StringError(errors.New("model unknown"))
+			}
+			field.SetString(prefix + "_" + field.String())
 		}
-		field.SetString(prefix + "_" + field.String())
+
+		// Relational IDs
+		for fieldName, prefix := range relationalIdPrefixes {
+			field := stype.FieldByName(fieldName)
+			if !field.IsValid() {
+				continue
+			}
+			field.SetString(prefix + "_" + field.String())
+		}
+
+		return nil
 	}
 
-	// Relational IDs
-	for fieldName, prefix := range relationalIdPrefixes {
-		field := stype.FieldByName(fieldName)
-		if !field.IsValid() {
-			continue
+	// Modify inline string pointers based on struct values
+	if len(inline) > 0 {
+		if len(inline) != stype.NumField() {
+			return StringError(errors.New("invalid inline length"))
 		}
-		field.SetString(prefix + "_" + field.String())
+		for i := 0; i < stype.NumField(); i++ {
+			field := stype.Field(i)
+			prefix, ok := relationalIdPrefixes[stype.Type().Field(i).Name]
+			if !ok {
+				return StringError(errors.New("unknown field type " + field.Type().Name()))
+			}
+			*inline[i] = prefix + "_" + field.String()
+		}
 	}
 
 	return nil

--- a/common/id_prefix_test.go
+++ b/common/id_prefix_test.go
@@ -46,3 +46,23 @@ func TestSanitizeRelationalModelOutput(t *testing.T) {
 	assert.Equal(t, "contact_123", m.ContactId)
 	assert.Equal(t, "platform_456", m.PlatformId)
 }
+
+func TestSanitizeInputInline(t *testing.T) {
+	m := "user_123"
+	m2 := "platform_456"
+
+	err := SanitizeIdInput(&struct{ UserId, PlatformId string }{m, m2}, &m, &m2)
+	assert.NoError(t, err)
+	assert.Equal(t, "123", m)
+	assert.Equal(t, "456", m2)
+}
+
+func TestSanitizeOutputInline(t *testing.T) {
+	m := "123"
+	m2 := "456"
+
+	err := SanitizeIdOutput(&struct{ UserId, PlatformId string }{m, m2}, &m, &m2)
+	assert.NoError(t, err)
+	assert.Equal(t, "user_123", m)
+	assert.Equal(t, "platform_456", m2)
+}

--- a/common/id_prefix_test.go
+++ b/common/id_prefix_test.go
@@ -1,0 +1,48 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type User struct {
+	Id             string `json:"id" db:"id"`
+	SomeField      string `json:"somefield" db:"somefield"`
+	SomeOtherField int    `json:"someotherfield" db:"someotherfield"`
+}
+
+type ContactToPlatform struct {
+	ContactId  string `json:"contactId" db:"contact_id"`
+	PlatformId string `json:"platformId" db:"platform_id"`
+}
+
+func TestSanitizeModelInput(t *testing.T) {
+	m := User{Id: "user_0923840923840923840923"}
+	err := SanitizeIdInput(&m)
+	assert.NoError(t, err)
+	assert.Equal(t, "0923840923840923840923", m.Id)
+}
+
+func TestSanitizeModelOutput(t *testing.T) {
+	m := User{Id: "0923840923840923840923"}
+	err := SanitizeIdOutput(&m)
+	assert.NoError(t, err)
+	assert.Equal(t, "user_0923840923840923840923", m.Id)
+}
+
+func TestSanitizeRelationalModelInput(t *testing.T) {
+	m := ContactToPlatform{ContactId: "contact_123", PlatformId: "platform_456"}
+	err := SanitizeIdInput(&m)
+	assert.NoError(t, err)
+	assert.Equal(t, "123", m.ContactId)
+	assert.Equal(t, "456", m.PlatformId)
+}
+
+func TestSanitizeRelationalModelOutput(t *testing.T) {
+	m := ContactToPlatform{ContactId: "123", PlatformId: "456"}
+	err := SanitizeIdOutput(&m)
+	assert.NoError(t, err)
+	assert.Equal(t, "contact_123", m.ContactId)
+	assert.Equal(t, "platform_456", m.PlatformId)
+}


### PR DESCRIPTION
Added ID prefixing!  You can run the new test script.  The String API and Admin API have been updated to use this new functionality at the endpoint level to remove the prefixes from user inputs and add them to user facing outputs.