### PR TITLE
Add http response code to function names

### DIFF
--- a/httperror/http_error.go
+++ b/httperror/http_error.go
@@ -18,62 +18,62 @@ type Details struct {
 	Params *validator.InvalidParams `json:"invalidParams,omitempty"`
 }
 
-func InvalidPayloadError(c echo.Context, err error) error {
+func InvalidPayload400(c echo.Context, err error) error {
 	errorParams := validator.ExtractErrorParams(err)
 	message := errorParams[0].Message
 	return c.JSON(http.StatusBadRequest, JSONError{Message: message, Code: "BAD_REQUEST", Details: &Details{Params: &errorParams}})
 }
 
-func BadRequestError(c echo.Context, message ...string) error {
+func BadRequest400(c echo.Context, message ...string) error {
 	if len(message) > 0 {
 		return c.JSON(http.StatusBadRequest, JSONError{Message: strings.Join(message, " "), Code: "BAD_REQUEST"})
 	}
 	return c.JSON(http.StatusBadRequest, JSONError{Message: "Bad Request", Code: "BAD_REQUEST"})
 }
 
-func ConflictError(c echo.Context, message ...string) error {
+func Conflict409(c echo.Context, message ...string) error {
 	if len(message) > 0 {
 		return c.JSON(http.StatusConflict, JSONError{Message: strings.Join(message, " "), Code: "CONFLICT"})
 	}
 	return c.JSON(http.StatusConflict, JSONError{Message: "Conflict", Code: "CONFLICT"})
 }
 
-func ForbiddenError(c echo.Context, message ...string) error {
+func Forbidden403(c echo.Context, message ...string) error {
 	if len(message) > 0 {
 		return c.JSON(http.StatusForbidden, JSONError{Message: strings.Join(message, " "), Code: "FORBIDDEN"})
 	}
 	return c.JSON(http.StatusForbidden, JSONError{Message: "not enough permissions", Code: "FORBIDDEN"})
 }
 
-func NotFoundError(c echo.Context, message ...string) error {
+func NotFound404(c echo.Context, message ...string) error {
 	if len(message) > 0 {
 		return c.JSON(http.StatusNotFound, JSONError{Message: strings.Join(message, " "), Code: "NOT_FOUND"})
 	}
 	return c.JSON(http.StatusNotFound, JSONError{Message: "Resource Not Found", Code: "NOT_FOUND"})
 }
 
-func Unauthorized(c echo.Context, message ...string) error {
+func Unauthorized401(c echo.Context, message ...string) error {
 	if len(message) > 0 {
 		return c.JSON(http.StatusUnauthorized, JSONError{Message: strings.Join(message, " "), Code: "UNAUTHORIZED"})
 	}
 	return c.JSON(http.StatusUnauthorized, JSONError{Message: "This action requires authentication", Code: "UNAUTHORIZED"})
 }
 
-func InternalError(c echo.Context, message ...string) error {
+func Internal500(c echo.Context, message ...string) error {
 	if len(message) > 0 {
 		return c.JSON(http.StatusInternalServerError, JSONError{Message: strings.Join(message, " "), Code: "INTERNAL_SERVER"})
 	}
 	return c.JSON(http.StatusInternalServerError, JSONError{Message: "Something went wrong", Code: "INTERNAL_SERVER"})
 }
 
-func Unprocessable(c echo.Context, message ...string) error {
+func Unprocessable422(c echo.Context, message ...string) error {
 	if len(message) > 0 {
 		return c.JSON(http.StatusUnprocessableEntity, JSONError{Message: strings.Join(message, " "), Code: "UNPROCESSABLE_ENTITY"})
 	}
 	return c.JSON(http.StatusUnprocessableEntity, JSONError{Message: "Unable to process entity", Code: "UNPROCESSABLE_ENTITY"})
 }
 
-func NotAllowedError(c echo.Context, message ...string) error {
+func NotAllowed405(c echo.Context, message ...string) error {
 	if len(message) > 0 {
 		return c.JSON(http.StatusMethodNotAllowed, JSONError{Message: strings.Join(message, " "), Code: "NOT_ALLOWED"})
 	}


### PR DESCRIPTION
# Changes
Updated all httperror function names to remove "Error" and add the http status code.

# To Test
Confirm the test procedures laid out in https://github.com/String-xyz/platform-admin-api/pull/63 and https://github.com/String-xyz/string-api/pull/189 are passing. Each of those use this PR