### PR TITLE
move LoadEnv into golib

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/joho/godotenv"
+	"github.com/rs/zerolog/log"
+)
+
+func LoadEnv(collection any, params ...string) error {
+	path := ".env"
+	if len(params) >= 1 && params[0] != "" {
+		path = params[0]
+	}
+	godotenv.Load(path)
+	missing := []string{}
+	stype := reflect.ValueOf(collection).Elem()
+	for i := 0; i < stype.NumField(); i++ {
+		field := stype.Field(i)
+		key := stype.Type().Field(i).Name
+		value := os.Getenv(key)
+		required := stype.Type().Field(i).Tag.Get("required") == "true"
+		optional := stype.Type().Field(i).Tag.Get("required") == "false"
+		if required && value == "" {
+			missing = append(missing, key)
+		}
+		if optional && value == "" {
+			// lets not panic, but warn
+			log.Warn().Str("env var", key).Msg("Optional environment variable not set")
+		}
+		field.SetString(value)
+	}
+	if len(missing) > 0 {
+		panic("Missing environment variable: " + strings.Join(missing, ", "))
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/go-redis/redis/v8 v8.0.0
 	github.com/jmoiron/sqlx v1.3.5
+	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.10.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
 github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
To test:

1) In string-api, platform admin and migrations, `go get github.com/String-xyz/go-lib/v2@18a2f8db8ec47e11091ed54214789a519334194e`
2) `go mod tidy`
3) Ensure that the codebase is referring to the LoadEnv defined in this PR
4) Hit a few endpoints and make sure everything works