### PR TITLE
Update IsUUID to use the type of UUID we are using. 

### DIFF
--- a/validator/validator.go
+++ b/validator/validator.go
@@ -86,11 +86,22 @@ func IsUUID(id ...string) bool {
 	validate := validator.New()
 
 	for _, i := range id {
-		if err := validate.Var(i, "uuid"); err != nil {
+		if err := validate.Var(i, "uuid4"); err != nil {
 			return false
 		}
 	}
 
+	return true
+}
+
+// https://github.com/go-playground/validator#baked-in-validations
+func Is(tag string, values ...string) bool {
+	v := validator.New()
+	for _, q := range values {
+		if err := v.Var(q, tag); err != nil {
+			return false
+		}
+	}
 	return true
 }
 


### PR DESCRIPTION
 Also added generic wrapper for any validator tag (validator.Is("tag", objects...))

To test:

Try calling the validator on the UUID.  Example:

1) In the Dashboard API, point it at this commit hash using `go get github.com/String-xyz/go-lib/v2@f8e98da8085bd140da67e03f7be2f7a9815b0cb5`
2) Rebuild the Dashboard API (docker compose down, docker compose up --build)
3) Try calling an endpoint which uses the uuid validator (such as Api Key DELETE):
<img width="745" alt="image" src="https://github.com/String-xyz/go-lib/assets/7332587/7cceb056-c7f5-4f71-a05c-f7d6f5e3932b">
4) Try passing in a valid UUID4, the endpoint should behave as expected (delete the API key specified)
5) Try passing in something which is not a valid UUID4 (such as the string "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), the endpoint should complain about it.